### PR TITLE
Cross out 4x speed icon when forced 1x

### DIFF
--- a/Source/EasySpeedup.csproj
+++ b/Source/EasySpeedup.csproj
@@ -12,6 +12,7 @@
     <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
+    <RimWorldLibsPath>..\..\..\RimWorldWin64_Data\Managed\</RimWorldLibsPath>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>false</DebugSymbols>
@@ -39,7 +40,7 @@
       <Private>False</Private>
     </Reference>
     <Reference Include="Assembly-CSharp">
-      <HintPath>..\..\..\RimWorldWin64_Data\Managed\Assembly-CSharp.dll</HintPath>
+      <HintPath>$(RimWorldLibsPath)\Assembly-CSharp.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="System" />
@@ -49,7 +50,7 @@
     <Reference Include="System.Data" />
     <Reference Include="System.Xml" />
     <Reference Include="UnityEngine.CoreModule">
-      <HintPath>..\..\..\RimWorldWin64_Data\Managed\UnityEngine.CoreModule.dll</HintPath>
+      <HintPath>$(RimWorldLibsPath)\UnityEngine.CoreModule.dll</HintPath>
       <Private>False</Private>
     </Reference>
   </ItemGroup>

--- a/Source/HarmonyPatches.cs
+++ b/Source/HarmonyPatches.cs
@@ -15,27 +15,30 @@ namespace EasySpeedup
         {
             var harmony = new Harmony("EasySpeedup");
             harmony.PatchAll(Assembly.GetExecutingAssembly());
-            ((Texture2D[]) typeof(Thing).Assembly.GetType("Verse.TexButton").GetField("SpeedButtonTextures").GetValue(null))[4] =
+
+            ((Texture2D[]) typeof(Thing).Assembly.GetType("Verse.TexButton").GetField(nameof(TexButton.SpeedButtonTextures)).GetValue(null))[4] =
                 ContentFinder<Texture2D>.Get("UI/TimeControls/TimeSpeedButton_Ultrafast", true);
         }
     }
 
-
-    [HarmonyPatch(typeof(TimeControls), "DoTimeControlsGUI")] // Target class for patching, generally required.
+    [HarmonyPatch(typeof(TimeControls), nameof(TimeControls.DoTimeControlsGUI))] // Target class for patching, generally required.
     public static class TimeControlsPatch
     {
-        private static MethodInfo devGetter = AccessTools.Property(typeof(Prefs), nameof(Prefs.DevMode)).GetGetMethod();
+        private static readonly MethodInfo devGetter = AccessTools.Property(typeof(Prefs), nameof(Prefs.DevMode)).GetGetMethod();
+
         // stops checks for devmode enabled and draws/activates 4x speed mode
         public static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> instructions)
         {
             // replace codeinstructions in order
-            List<CodeInstruction> list = new List<CodeInstruction>(instructions);
-            bool buttonDrawn = false,
-                 devModeEnabled = false;
+            var list = new List<CodeInstruction>(instructions);
+            var buttonDrawn = false;
+            var devModeEnabled = false;
 
-            for (int i = 0; i < list.Count; i++) {
+            for (var i = 0; i < list.Count; i++) {
+                var code = list[i];
+
                 // find opcode before the check for the 5th speed option (ultra), skips conditional
-                if (!buttonDrawn && list[i].opcode == OpCodes.Ldloc_3) {
+                if (!buttonDrawn && code.opcode == OpCodes.Ldloc_3) {
                     i += 3;
                     buttonDrawn = true;
                     yield return new CodeInstruction(list[i]);
@@ -43,8 +46,7 @@ namespace EasySpeedup
                 }
 
                 // find opcode where they check if DevMode is enabled, and replace it with a True
-                if (!devModeEnabled && list[i].opcode == OpCodes.Call && list[i].operand == devGetter) {
-                    CodeInstruction code = list[i];
+                if (!devModeEnabled && code.Calls(devGetter)) {
                     code.opcode = OpCodes.Ldc_I4_1;
                     devModeEnabled = true;
                     yield return code;
@@ -52,7 +54,7 @@ namespace EasySpeedup
                 }
 
                 // yield latest codeinstruction
-                yield return list[i];
+                yield return code;
             }
         }
 
@@ -60,7 +62,7 @@ namespace EasySpeedup
         public static void Prefix(ref Rect timerRect)
         {
             timerRect.x -= 35f;
-            timerRect.width +=35f;
+            timerRect.width += 35f;
         }
     }
 }


### PR DESCRIPTION
This MR adds a check for a `Widgets.DrawLineHorizontal` call and corrects forced 1x speed line width to include third (4x) speed button.

Fixes #2.

Checked against RimWorld 1.4.3682 (64-bit).

I modernized code a bit. Hope you don't mind.